### PR TITLE
Task/CRM-76-export-data-of-leads-as-execl-csv-FrontEnd

### DIFF
--- a/src/app/admin/interlocutor/interlocutor.component.html
+++ b/src/app/admin/interlocutor/interlocutor.component.html
@@ -43,7 +43,7 @@
                  mat-menu-item class="mat-primary">
           <mat-icon class="p-0 overflow-visible"><i class="bi bi-filetype-csv primary-blue-color"></i></mat-icon>  Import
         </button>
-        <button  mat-menu-item class="mat-primary">
+        <button (click)="exportToExcel()" mat-menu-item class="mat-primary">
           <mat-icon><i class="bi bi-cloud-arrow-down primary-blue-color"></i></mat-icon>  Export
         </button>
       </mat-menu>

--- a/src/app/admin/prospect/prospect.component.html
+++ b/src/app/admin/prospect/prospect.component.html
@@ -45,7 +45,7 @@
           mat-menu-item class="mat-primary">
           <mat-icon class="p-0 overflow-visible"><i class="bi bi-filetype-csv primary-blue-color"></i></mat-icon>  Import
         </button>
-        <button  mat-menu-item class="mat-primary">
+        <button (click)="exportToExcel()" mat-menu-item class="mat-primary">
           <mat-icon><i class="bi bi-cloud-arrow-down primary-blue-color"></i></mat-icon>  Export
         </button>
       </mat-menu>

--- a/src/app/admin/prospect/prospect.component.ts
+++ b/src/app/admin/prospect/prospect.component.ts
@@ -344,4 +344,39 @@ export class ProspectComponent implements OnInit, AfterViewInit {
   }
 
   protected readonly ProspectStatus = ProspectStatus;
+
+  exportToExcel(): void {
+    // Prepare the selected prospects (if any)
+    const selectedProspects = this.selectedRows.size > 0
+        ? this.dataSource.data.filter((row) => this.selectedRows.has(row.id))
+        : undefined;
+
+    // Call the service to export prospects
+    this.prospectService.exportProspects(selectedProspects).subscribe(
+        (response: Blob) => {
+          // Trigger file download
+          this.downloadProspectFile(response, 'Prospects_file.xlsx');
+        },
+        (error) => {
+          console.error('Error exporting data:', error);
+          this.snackBar.open('Failed to export data', 'Close', {
+            duration: 3000,
+          });
+        }
+    );
+  }
+
+  /**
+   * Trigger file download
+   */
+  private downloadProspectFile(blob: Blob, fileName: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  }
 }

--- a/src/services/Leads/interlocutor.service.ts
+++ b/src/services/Leads/interlocutor.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {environment} from '../../environments/environment';
 import {Observable, tap} from 'rxjs';
 import {InterlocutorRequestDto} from '../../dtos/request/interlocutorRequestDto';
@@ -52,7 +52,17 @@ export class InterlocutorService {
     );
   }
 
+  exportInterlocutor(selectedInterlocutors?: any[]): Observable<Blob> {
+    let params = new HttpParams();
+    if (selectedInterlocutors && selectedInterlocutors.length > 0) {
+      // Convert the selected prospects to a JSON string
+      const interlocutorsJson = JSON.stringify(selectedInterlocutors);
+      params = params.set('interlocutorsJson', interlocutorsJson);
+    }
 
-
-
+    return this.http.get(`${this.baseUrl}/export`, {
+      params,
+      responseType: 'blob', // Expect a binary response (Excel file)
+    });
+  }
 }

--- a/src/services/Leads/prospect.service.ts
+++ b/src/services/Leads/prospect.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from "@angular/core";
 
-import {HttpClient, HttpRequest} from "@angular/common/http";
+import {HttpClient, HttpParams, HttpRequest} from "@angular/common/http";
 import {Observable, tap} from "rxjs";
 import {CreateCompanyRequest} from "../../dtos/request/CreateCompanyDto";
 import {environment} from '../../environments/environment';
@@ -96,5 +96,19 @@ export class ProspectService {
         tap(interestRequestDto => {
           new ProspectInterestResponseDto(ProspectInterestResponseDto)})
     )
+  }
+
+  exportProspects(selectedProspects?: any[]): Observable<Blob> {
+    let params = new HttpParams();
+    if (selectedProspects && selectedProspects.length > 0) {
+      // Convert the selected prospects to a JSON string
+      const prospectsJson = JSON.stringify(selectedProspects);
+      params = params.set('prospectsJson', prospectsJson);
+    }
+
+    return this.http.get(`${this.baseUrl}/export`, {
+      params,
+      responseType: 'blob', // Expect a binary response (Excel file)
+    });
   }
 }


### PR DESCRIPTION
This PR adds functionality to export prospects data to an Excel file. Users can either export all prospects or selected prospects from the table. The backend generates the Excel file and returns it as a binary response (`Blob`), which is then downloaded by the frontend.

**1. Service Update:**
- Added a new method `exportProspects` in the `ProspectService` to handle exporting prospects data.
- Added a new method `exportInterlocutors` in the `InterlocutorService` to handle exporting interlocutors data.

**2. Component Update:**
- Added a new method `exportToExcel` in the `ProspectComponent` to handle the export logic for prospects.
- Added a new method `exportToExcel` in the `InterlocutorComponent` to handle the export logic for interlocutors.
- Added a shared utility method `downloadProspectFile` | `downloadInterlocutorFile` to trigger file downloads for both components.

**3. Template Update:**
- Added an "Export" button in the `mat-menu` for both `Prospect` and `Interlocutor` tables to trigger the export functionality.